### PR TITLE
Initial implementation of debug-logtron

### DIFF
--- a/backends/debug-log-backend.js
+++ b/backends/debug-log-backend.js
@@ -1,17 +1,20 @@
 'use strict';
 
 var Writable = require('readable-stream/writable');
-var debuglog = require('debuglog');
+var globalDebuglog = require('debuglog');
 var inspect = require('util/').inspect;
 
 module.exports = DebugLogBackend;
 
-function DebugLogBackend(namespace) {
+function DebugLogBackend(namespace, opts) {
     if (!(this instanceof DebugLogBackend)) {
-        return new DebugLogBackend(namespace);
+        return new DebugLogBackend(namespace, opts);
     }
 
-    this.debuglog = debuglog(namespace);
+    var debuglog = opts.debuglog ||
+        /*istanbul ignore next */ globalDebuglog;
+
+    this.log = debuglog(namespace);
 }
 
 var proto = DebugLogBackend.prototype;
@@ -27,11 +30,11 @@ proto.createStream = function createStream() {
     return stream;
 
     function write(logRecord, enc, cb) {
-        var msg = logRecord.levelName + ' ' +
-            logRecord.fields.msg + ' ' +
-            inspect(logRecord.fields.meta);
+        var msg = logRecord.levelName + ': ' +
+            logRecord.fields.msg + ' ~ ' +
+            inspect(logRecord.meta);
 
-        self.debuglog(msg);
+        self.log(msg);
         cb();
     }
 };

--- a/backends/debug-log-backend.js
+++ b/backends/debug-log-backend.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var Writable = require('readable-stream/writable');
+var debuglog = require('debuglog');
+var inspect = require('util/').inspect;
+
+module.exports = DebugLogBackend;
+
+function DebugLogBackend(namespace) {
+    if (!(this instanceof DebugLogBackend)) {
+        return new DebugLogBackend(namespace);
+    }
+
+    this.debuglog = debuglog(namespace);
+}
+
+var proto = DebugLogBackend.prototype;
+
+proto.createStream = function createStream() {
+    var self = this;
+    var stream = new Writable({
+        objectMode: true
+    });
+
+    stream._write = write;
+
+    return stream;
+
+    function write(logRecord, enc, cb) {
+        var msg = logRecord.levelName + ' ' +
+            logRecord.fields.msg + ' ' +
+            inspect(logRecord.fields.meta);
+
+        self.debuglog(msg);
+        cb();
+    }
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,76 @@
-function debugLogtron() {
-    
+'use strict';
+
+var TypedError = require('error/typed');
+
+var LogRecord = require('./log-record.js');
+var DebugLogBackend = require('./backends/debug-log-backend.js');
+var LEVELS = require('./levels.js');
+
+var validNamespaceRegex = /[a-zA-Z0-9]+/;
+var InvalidNamespaceError = TypedError({
+    type: 'debug-logtron.invalid-argument.namespace',
+    message: 'Unexpected characters in the `namespace` arg.\n' +
+        'Expected the namespace to be a bare word but instead ' +
+            'found {badChar} character.\n' +
+        'SUGGESTED FIX: Use just alphanum in the namespace.\n',
+    badChar: null,
+    reason: null,
+    namespace: null
+});
+
+module.exports = DebugLogtron;
+
+function DebugLogtron(namespace) {
+    if (!(this instanceof DebugLogtron)) {
+        return new DebugLogtron(namespace);
+    }
+
+    var isValid = validNamespaceRegex.test(namespace);
+    if (!isValid) {
+        var hasHypen = namespace.indexOf('-') >= 0;
+        var hasSpace = namespace.indexOf(' ') >= 0;
+
+        throw InvalidNamespaceError({
+            namespace: namespace,
+            badChar: hasHypen ? '-' : hasSpace ? ' ' : 'bad',
+            reason: hasHypen ? 'hypen' :
+                hasSpace ? 'space' : 'unknown'
+        });
+    }
+
+    this.name = namespace;
+
+    this._backend = DebugLogBackend(namespace);
+    this._stream = this._backend.createStream();
 }
 
-module.exports = debugLogtron;
+var proto = DebugLogtron.prototype;
+
+proto._log = function _log(level, msg, meta, cb) {
+    var logRecord = new LogRecord(level, msg, meta);
+    LogRecord.isValid(logRecord);
+
+    logRecord.name = this.name;
+
+    this._stream.write(logRecord);
+};
+
+proto.debug = function debug(msg, meta, cb) {
+    this._log(LEVELS.debug, msg, meta, cb);
+};
+
+proto.info = function info(msg, meta, cb) {
+    this._log(LEVELS.info, msg, meta, cb);
+};
+
+proto.warn = function warn(msg, meta, cb) {
+    this._log(LEVELS.warn, msg, meta, cb);
+};
+
+proto.error = function error(msg, meta, cb) {
+    this._log(LEVELS.error, msg, meta, cb);
+};
+
+proto.fatal = function fatal(msg, meta, cb) {
+    this._log(LEVELS.fatal, msg, meta, cb);
+};

--- a/levels.js
+++ b/levels.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var LEVELS = {
+var LEVELS_BY_NAME = {
     'trace': 10,
     'debug': 20,
     'info': 30,
@@ -9,4 +9,16 @@ var LEVELS = {
     'fatal': 60
 };
 
-module.exports = LEVELS;
+var LEVELS_BY_VALUE = {
+    '10': 'trace',
+    '20': 'debug',
+    '30': 'info',
+    '40': 'warn',
+    '50': 'error',
+    '60': 'fatal'
+};
+
+module.exports = {
+    LEVELS_BY_NAME: LEVELS_BY_NAME,
+    LEVELS_BY_VALUE: LEVELS_BY_VALUE
+};

--- a/levels.js
+++ b/levels.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var LEVELS = {
+    'trace': 10,
+    'debug': 20,
+    'info': 30,
+    'warn': 40,
+    'error': 50,
+    'fatal': 60
+};
+
+module.exports = LEVELS;

--- a/log-message.js
+++ b/log-message.js
@@ -7,33 +7,35 @@ var Buffer = require('buffer').Buffer;
 var CircularJSON = require('circular-json');
 var extend = require('xtend');
 
-var LEVELS = require('./levels.js');
+var LEVELS = require('./levels.js').LEVELS_BY_VALUE;
 
-LogRecord.isValid = isValid;
-LogRecord.JSONLogRecord = JSONLogRecord;
+LogMessage.isValid = isValid;
+LogMessage.JSONLogRecord = JSONLogRecord;
 
-module.exports = LogRecord;
+module.exports = LogMessage;
 
-function LogRecord(level, msg, meta) {
-    if (!(this instanceof LogRecord)) {
-        return new LogRecord(level, msg, meta);
+function LogMessage(level, msg, meta, time) {
+    if (!(this instanceof LogMessage)) {
+        return new LogMessage(level, msg, meta);
     }
 
     this.level = level;
+    this.levelName = LEVELS[level];
     this.msg = msg;
 
     this.meta = (meta === null || meta === void 0) ? null : meta;
 
+    this._time = time;
     this._jsonLogRecord = null;
     this._buffer = null;
 }
 
-var proto = LogRecord.prototype;
+var proto = LogMessage.prototype;
 
 proto.toLogRecord = function toBuffer() {
     if (!this._jsonLogRecord) {
         this._jsonLogRecord = new JSONLogRecord(
-            this.level, this.msg, this.meta);
+            this.level, this.msg, this.meta, this._time);
     }
 
     return this._jsonLogRecord;
@@ -51,9 +53,9 @@ proto.toBuffer = function toBuffer() {
 };
 
 /* JSONLogRecord. The same interface as bunyan on the wire */
-function JSONLogRecord(level, msg, meta) {
+function JSONLogRecord(level, msg, meta, time) {
     if (!(this instanceof JSONLogRecord)) {
-        return new JSONLogRecord(level, msg, meta);
+        return new JSONLogRecord(level, msg, meta, time);
     }
 
     this.fields = extend(meta, {
@@ -63,7 +65,7 @@ function JSONLogRecord(level, msg, meta) {
         component: null,
         level: level,
         msg: msg,
-        time: (new Date()).toISOString(),
+        time: time || (new Date()).toISOString(),
         src: null,
         v: 0
     });

--- a/log-record.js
+++ b/log-record.js
@@ -1,0 +1,84 @@
+'use strict';
+
+var assert = require('assert/');
+var process = require('process/');
+var os = require('os');
+var Buffer = require('buffer').Buffer;
+var CircularJSON = require('circular-json');
+var extend = require('xtend');
+
+var LEVELS = require('./levels.js');
+
+LogRecord.isValid = isValid;
+LogRecord.JSONLogRecord = JSONLogRecord;
+
+module.exports = LogRecord;
+
+function LogRecord(level, msg, meta) {
+    if (!(this instanceof LogRecord)) {
+        return new LogRecord(level, msg, meta);
+    }
+
+    this.level = level;
+    this.msg = msg;
+
+    this.meta = (meta === null || meta === void 0) ? null : meta;
+
+    this._jsonLogRecord = null;
+    this._buffer = null;
+}
+
+var proto = LogRecord.prototype;
+
+proto.toLogRecord = function toBuffer() {
+    if (!this._jsonLogRecord) {
+        this._jsonLogRecord = new JSONLogRecord(
+            this.level, this.msg, this.meta);
+    }
+
+    return this._jsonLogRecord;
+};
+
+proto.toBuffer = function toBuffer() {
+    if (!this._buffer) {
+        var logRecord = this.toLogRecord();
+
+        var jsonStr = CircularJSON.stringify(logRecord.fields);
+        this._buffer = new Buffer(jsonStr);
+    }
+
+    return this._buffer;
+};
+
+/* JSONLogRecord. The same interface as bunyan on the wire */
+function JSONLogRecord(level, msg, meta) {
+    if (!(this instanceof JSONLogRecord)) {
+        return new JSONLogRecord(level, msg, meta);
+    }
+
+    this.fields = extend(meta, {
+        name: null,
+        hostname: os.hostname(),
+        pid: process.pid,
+        component: null,
+        level: level,
+        msg: msg,
+        time: (new Date()).toISOString(),
+        src: null,
+        v: 0
+    });
+
+    this.levelName = LEVELS[level];
+    this.meta = meta;
+}
+
+function isValid(logRecord) {
+    assert(typeof logRecord.level === 'number',
+        'level must be a number');
+    assert(typeof logRecord.msg === 'string',
+        'msg must be a string');
+
+    assert(logRecord.meta === null ||
+        typeof logRecord.meta === 'object',
+        'meta must be an object');
+}

--- a/package.json
+++ b/package.json
@@ -11,27 +11,40 @@
     "url": "https://github.com/Raynos/debug-logtron/issues",
     "email": "raynos2@gmail.com"
   },
-  "contributors": [{
-    "name": "Raynos"
-  }],
+  "contributors": [
+    {
+      "name": "Raynos"
+    }
+  ],
   "dependencies": {
+    "assert": "^1.3.0",
+    "circular-json": "^0.1.6",
+    "debuglog": "^1.0.1",
+    "error": "^5.0.0",
+    "process": "^0.10.0",
+    "readable-stream": "^1.0.33",
+    "util": "^0.10.3",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.10.0",
     "istanbul": "^0.3.5",
+    "lint-trap": "^1.0.0",
     "opn": "^1.0.1",
     "pre-commit": "0.0.11",
     "tap-spec": "^2.1.1",
     "tape": "^3.4.0"
   },
-  "licenses": [{
-    "type": "MIT",
-    "url": "http://github.com/Raynos/debug-logtron/raw/master/LICENSE"
-  }],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://github.com/Raynos/debug-logtron/raw/master/LICENSE"
+    }
+  ],
   "scripts": {
     "test": "npm run jshint -s && npm run cover -s",
     "unit-test": "node test/index.js | tap-spec",
-    "jshint": "jshint --verbose .",
+    "jshint": "lint-trap .",
     "cover": "istanbul cover --report html --print detail -- test/index.js && npm run check-cover -s",
     "check-cover": "istanbul check-coverage --branches=100 --lines=100 --functions=100",
     "view-cover": "opn ./coverage/index.html",

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,10 @@
+'use strict';
+
 var test = require('tape');
 
 var debugLogtron = require('../index.js');
 
-test('debugLogtron is a function', function (assert) {
+test('debugLogtron is a function', function t(assert) {
     assert.equal(typeof debugLogtron, 'function');
     assert.end();
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,191 @@
 'use strict';
 
 var test = require('tape');
+var process = require('process/');
+var os = require('os');
 
-var debugLogtron = require('../index.js');
+var DebugLogtron = require('../index.js');
+var LogMessage = require('../log-message.js');
+var JSONLogRecord = LogMessage.JSONLogRecord;
 
-test('debugLogtron is a function', function t(assert) {
-    assert.equal(typeof debugLogtron, 'function');
+test('DebugLogtron is a function', function t(assert) {
+    assert.equal(typeof DebugLogtron, 'function');
     assert.end();
 });
+
+test('can create logger', function t(assert) {
+    var logger = allocLogger();
+
+    logger.debug('hi');
+
+    assert.equal(logger.lines.length, 1);
+
+    var line = logger.lines[0];
+    assert.equal(line.namespace, 'debuglogtron');
+    assert.equal(line.msg, 'debug: hi ~ null');
+
+    assert.end();
+});
+
+test('logger throws with bad namespace', function t(assert) {
+    assert.throws(function throwIt() {
+        DebugLogtron('bad name');
+    }, /found space character/);
+    assert.throws(function throwIt() {
+        DebugLogtron('bad-name');
+    }, /found - character/);
+    assert.throws(function throwIt() {
+        DebugLogtron('bad#name');
+    }, /found bad character/);
+
+    assert.end();
+});
+
+test('logger defaults opts', function t(assert) {
+    assert.doesNotThrow(function noThrow() {
+        DebugLogtron('somenamespace');
+    });
+
+    assert.end();
+});
+
+test('logger levels', function t(assert) {
+    /*eslint max-statements: 0*/
+    var logger = allocLogger();
+
+    logger.trace('trace');
+    logger.debug('debug');
+    logger.info('info');
+    logger.warn('warn');
+    logger.error('error');
+    logger.fatal('fatal');
+
+    assert.equal(logger.lines.length, 6);
+
+    var line = logger.lines[0];
+    assert.equal(line.namespace, 'debuglogtron');
+    assert.equal(line.msg, 'trace: trace ~ null');
+
+    var line2 = logger.lines[1];
+    assert.equal(line2.namespace, 'debuglogtron');
+    assert.equal(line2.msg, 'debug: debug ~ null');
+
+    var line3 = logger.lines[2];
+    assert.equal(line3.namespace, 'debuglogtron');
+    assert.equal(line3.msg, 'info: info ~ null');
+
+    var line4 = logger.lines[3];
+    assert.equal(line4.namespace, 'debuglogtron');
+    assert.equal(line4.msg, 'warn: warn ~ null');
+
+    var line5 = logger.lines[4];
+    assert.equal(line5.namespace, 'debuglogtron');
+    assert.equal(line5.msg, 'error: error ~ null');
+
+    var line6 = logger.lines[5];
+    assert.equal(line6.namespace, 'debuglogtron');
+    assert.equal(line6.msg, 'fatal: fatal ~ null');
+
+    assert.end();
+});
+
+test('fails with string meta', function t(assert) {
+    assert.throws(function throwIt() {
+        var logger = allocLogger();
+
+        logger.info('hi', 'string meta');
+    }, /meta must be an object/);
+
+    assert.end();
+});
+
+test('serialize meta', function t(assert) {
+    var logger = allocLogger();
+
+    logger.info('hello', {
+        complex: {
+            nested: true, foo: 'bar'
+        }
+    });
+
+    assert.equal(logger.lines.length, 1);
+    var line = logger.lines[0];
+
+    assert.equal(line.namespace, 'debuglogtron');
+    assert.equal(line.msg, 'info: hello ~ ' +
+        '{ complex: { nested: true, foo: \'bar\' } }');
+
+    assert.end();
+});
+
+test('JSONLogRecord without new', function t(assert) {
+    var logRecord = JSONLogRecord(20, 'hi', null);
+
+    assert.ok(logRecord);
+    assert.equal(logRecord.levelName, 'debug');
+    assert.equal(logRecord.meta, null);
+    assert.equal(logRecord.fields.msg, 'hi');
+
+    assert.end();
+});
+
+test('LogMessage without new', function t(assert) {
+    var logMessage = LogMessage(20, 'hi', null);
+
+    assert.ok(logMessage);
+    assert.equal(logMessage.levelName, 'debug');
+    assert.equal(logMessage.meta, null);
+    assert.equal(logMessage.msg, 'hi');
+
+    assert.end();
+});
+
+test('LogMessage to buffer', function t(assert) {
+    var hostname = os.hostname();
+
+    var time = (new Date()).toISOString();
+    var logMessage = LogMessage(20, 'hi', null, time);
+
+    var buf = logMessage.toBuffer();
+
+    assert.equal(String(buf),
+        '{"name":null,' +
+        '"hostname":"' + hostname + '",' +
+        '"pid":' + process.pid + ',' +
+        '"component":null,' +
+        '"level":20,' +
+        '"msg":"hi",' +
+        '"time":"' + time + '",' +
+        '"src":null,' +
+        '"v":0}'
+    );
+
+    var buf2 = logMessage.toBuffer();
+    assert.equal(buf, buf2);
+
+    var logRecord = logMessage.toLogRecord();
+    var logRecord2 = logMessage.toLogRecord();
+    assert.equal(logRecord, logRecord2);
+
+    assert.end();
+});
+
+function allocLogger() {
+    /* eslint no-process-env: 0 */
+    var prev = process.env.NODE_DEBUG;
+    process.env.NODE_DEBUG = 'debuglogtrontestcode';
+    var logger = DebugLogtron('debuglogtron', {
+        debuglog: function fakeDebuglog(namespace) {
+            return function logStatement(msg) {
+                logger.lines.push({
+                    namespace: namespace,
+                    msg: msg
+                });
+            };
+        }
+    });
+    logger.lines = [];
+    process.env.NODE_DEBUG = prev;
+
+    return logger;
+}


### PR DESCRIPTION
Use case:

A default logger when writing tests or doing
    local adhoc manual testing.

This is not a default logger, We will use a null
    logger for a default library logtron.

This initial implementation is only tests & code.

cc: @sh1mmer You've wanted this for a while :)
cc: @robskillington I said I would make this module

cc: @Matt-Esch